### PR TITLE
Replacing d3 dom manipulation with angular native

### DIFF
--- a/libs/ngx-genome-karyotype-plots/src/lib/svg-element/svg-element.component.html
+++ b/libs/ngx-genome-karyotype-plots/src/lib/svg-element/svg-element.component.html
@@ -1,1 +1,17 @@
-<figure id="svgplot"></figure>
+<figure id="svgplot">
+  <svg #svgElem
+       class="haplotype-plot"
+       id="hapkaryoplot-svg"
+       [attr.width]="width"
+       [attr.height]="height">
+    <g #plotElem
+       class="plot"
+       transform="translate(0, 15)"
+       [attr.height]="height - 60">
+      <g #plotContentsGroupElem
+         class="plot-contents"></g>
+      <!-- TODO: Check usage of the snps-* class here -->
+      <g class="snps-karyoplot"></g>
+    </g>
+  </svg>
+</figure>

--- a/libs/ngx-genome-karyotype-plots/src/lib/svg-element/svg-element.component.scss
+++ b/libs/ngx-genome-karyotype-plots/src/lib/svg-element/svg-element.component.scss
@@ -1,8 +1,15 @@
 .no-data-overlay-bg {
-  fill: rgba(255, 255, 255, 0.5);
+  background: rgba(0, 0, 0, 0.5);
 }
 
 .no-data-overlay-text {
   fill: #666;
+  background: rgba(0, 0, 0, 0.5);
   font-size: 50px;
+}
+
+.haplotype-plot {
+  background: #e8e8e8;
+  display: block;
+  margin: 2px auto 10px auto;
 }

--- a/libs/ngx-genome-karyotype-plots/src/lib/svg-element/svg-element.component.spec.ts
+++ b/libs/ngx-genome-karyotype-plots/src/lib/svg-element/svg-element.component.spec.ts
@@ -22,4 +22,9 @@ describe('SvgElementComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  // TODO TEST: this.svg should be set after ngAfterViewInit
+  // TODO TEST: this.plot should be set after ngAfterViewInit
+  // TODO TEST: this.plotContentsGroup should be set after ngAfterViewInit
+  // TODO TEST: mousePositionInfo should return correct info
 });

--- a/libs/ngx-genome-karyotype-plots/src/lib/svg-element/svg-element.component.ts
+++ b/libs/ngx-genome-karyotype-plots/src/lib/svg-element/svg-element.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {AfterViewInit, Component, ElementRef, Input, ViewChild} from '@angular/core';
 import * as d3 from "d3";
 
 @Component({
@@ -6,7 +6,7 @@ import * as d3 from "d3";
   templateUrl: './svg-element.component.html',
   styleUrls: ['./svg-element.component.scss']
 })
-export class SvgElementComponent implements OnInit {
+export class SvgElementComponent implements AfterViewInit {
 
   // TODO: Fix these types
   public svg!: any;
@@ -18,32 +18,24 @@ export class SvgElementComponent implements OnInit {
 
   public chrOrdinalScale: any;
 
+  public snpBar!: any;
+
   @Input() name: string = 'SVG Common!';
   @Input() width: number = 900;
   @Input() height: number = 900;
   @Input() margin: number = 50;
   @Input() intervalMode: boolean = false;
 
-  constructor() { }
+  @ViewChild('svgElem') public svgElem!: ElementRef<HTMLElement>;
+  @ViewChild('plotElem') public plotElem!: ElementRef<HTMLElement>;
+  @ViewChild('plotContentsGroupElem') public plotContentsElem!: ElementRef<HTMLElement>;
 
-  ngOnInit(): void {
-    this.createSvg();
-  }
+  constructor() {}
 
-  private createSvg(): void {
-    this.svg = d3.select("figure#hapkaryoplot")
-      .append("svg")
-      .attr("width", this.width + (this.margin * 2))
-      .attr("height", this.height + (this.margin * 2))
-      .append("g")
-      .attr("transform", "translate(" + this.margin + "," + this.margin + ")");
-    this.plot = this.svg
-      .append("g")
-      .attr("class", "plot")
-      .attr("transform", "translate(0, 15)");
-    this.plotContentsGroup = this.plot
-      .append("g")
-      .attr("class", "plot-contents")
+  ngAfterViewInit() {
+    this.svg = d3.select(this.svgElem.nativeElement);
+    this.plot = d3.select(this.plotElem.nativeElement);
+    this.plotContentsGroup = d3.select(this.plotContentsElem.nativeElement);
   }
 
   public mousePositionInfo(): {} {


### PR DESCRIPTION
This PR replaces d3 dom manipulation with native angular dom interaction. This is the preferred method of interacting with the dom in angular. 

This closes #43.